### PR TITLE
Look for autoload.php further up in the tree.

### DIFF
--- a/bin/tuli
+++ b/bin/tuli
@@ -5,7 +5,7 @@ error_reporting(~0);
 gc_disable();
 
 $found = false;
-for ($i = 2; $i >= 0; $i--) {
+for ($i = 4; $i >= 0; $i--) {
 	$file = __DIR__ . str_repeat('/..', $i) . "/vendor/autoload.php";
 	if (file_exists($file)) {
 		$found = true;


### PR DESCRIPTION
In an application that uses Tuli as a dependency the bin file would be located at `/my-app/vendor/ircmaxell/tuli/bin/tuli`, and by only going two steps up in the tree it would stop looking for the autoloader at `/my-app/vendor/ircmaxell/vendor/autoload.php`.
