### PR TITLE
Add void as a null type alias

### DIFF
--- a/lib/Tuli/Type.php
+++ b/lib/Tuli/Type.php
@@ -323,6 +323,7 @@ class Type {
             case 'callable':
                 return new Type(Type::TYPE_CALLABLE);
             case 'null':
+            case 'void':
                 return new Type(Type::TYPE_NULL);
             case 'numeric':
                 return Type::fromDecl('int|float');


### PR DESCRIPTION
Whether using "void" is a good practice could probably be argued, but it is pretty common in my experience.
